### PR TITLE
Fixes a number of bugs and styling issues with the info-panel.

### DIFF
--- a/src/app/components/info-panel/info-panel.component.html
+++ b/src/app/components/info-panel/info-panel.component.html
@@ -19,64 +19,57 @@
   </div>
 </div>
 
-<hr/>
-<button class="collapsible" (click)="clickMoreDetails()" [class.hide]="isShowDetails">More Details <span
-  class="material-icons">
-    keyboard_arrow_down
-</span></button>
+<hr />
+<button class="collapsible" (click)="clickMoreDetails()" [class.hidden]="isShowDetails">More Details
+  <span class="material-icons">keyboard_arrow_down</span>
+</button>
 <div class="expand" [hidden]="isHideDetails">
-  <div class="descriptions">
+  <div class="descriptions" [style.visibility]="!(leverage$ | async) ? 'hidden' : ''">
     <div class="left">
-      <p><img src="assets/line-green-white.png" width="30" height="6"/></p>
-      <p><img src="assets/line-dashed.png" width="30" height="3"/></p>
-      <p><img src="assets/line-dashed-small.png" width="30" height="3"/></p>
-      <p><img src="assets/line-red-white.png" width="30" height="6"/></p>
+      <p><img src="assets/line-green-white.png" width="30" height="6" /></p>
+      <p><img src="assets/line-dashed.png" width="30" height="3" /></p>
+      <p><img src="assets/line-dashed-small.png" width="30" height="3" /></p>
+      <p><img src="assets/line-red-white.png" width="30" height="6" /></p>
     </div>
     <div class="right">
-      <p> Price to gain +100% to your money</p>
-      <p>Price to gain +50% to your money</p>
-      <p> Price to gain +0% to your money</p>
-      <p>Price to lose {{percentToLoose$ | async | percent}} if you close your position by yourself
-        or lose {{(percentToLoose$ | async) + (liquidationPenaltyProcentage$ | async) | percent}} if your would force
-        closed.</p>
+      <p>Price to gain 100% of your money</p>
+      <p>Price to gain 50% of your money</p>
+      <p>Price to gain 0% of your money</p>
+      <p style="white-space: pre-line">Liquidation price<br />
+        • lose {{maxLossPercentage$ | async | percent}} if you close your position voluntarily<br />
+        • lose {{liquidationLossPercentage$ | async | percent}} if your position is forcefully closed</p>
     </div>
-    <hr/>
+    <hr />
   </div>
 
   <div class="gradient-wrapper">
     <div class="txt">{{priceToGain100$ | async | currency}}</div>
-    <div class="gradient"
-         (pointerenter)="mouseEnterChart($event)"
-         (pointermove)="mouseMoveInChart($event)"
-         (pointerleave)="mouseLeaveChart()"
-    >
-      <div class="solid" style="display: none;" #priceLine>
-      </div>
-      <div class="dashed" style="display: none;" #dashedLine>
+    <div class="gradient" (pointerleave)="mouseLeaveChart()" (pointerenter)="mouseEnterChart()" #gradient>
+      <div class="line gain50" [class.hidden]="!(leverage$ | async)" #dashedLine>
         <div class="txt bottom">{{priceToGain50$ | async | currency}}</div>
       </div>
-      <div class="dotted" style="display: none;" #dottedLine>
+      <div class="line current" [class.hidden]="!(leverage$ | async)" #dottedLine>
         <div class="txt bottom">{{priceToGain0$ | async | currency}}</div>
       </div>
-      <div>
-        <div class="txt bottom" style="display: block;" #bottomLineText>{{liquidationPrice$ | async | currency}}</div>
+      <div class="line liquidation" [class.hidden]="!(leverage$ | async)">
+        <div class="txt bottom" #bottomLineText>{{liquidationPrice$ | async | currency}}</div>
+      </div>
+      <div class="at-cursor" [class.hidden]="!isMouseInChart || !(leverage$ | async)" #priceLine>
       </div>
     </div>
   </div>
+  <div class="bighint shadow" [class.hidden]="!isMouseInChart || !(leverage$ | async)" style="top: -200px" #toolTipBox>
+    <div>
+      <span>Price</span>
+      <span class="right" #toolTipPrice> {{priceAtCursor$ | async | currency}}</span>
+    </div>
+    <div>
+      <span>Position Value:</span>
+      <span class="right" #toolTipPortfolioValue> {{portfolioValueAtCursor$ | async | currency}}</span>
+    </div>
+    <i></i>
+  </div>
 </div>
-<div class="closebutton" (click)="clickMoreDetails()" [hidden]="isHideDetails">Close details <span
-  class="material-icons">
+<div class="closebutton" (click)="clickMoreDetails()" [class.hidden]="isHideDetails">Close details <span class="material-icons">
     keyboard_arrow_up
-</span></div>
-
-<div class="bighint shadow" style="display: inline-block;" #toolTipBox>
-  <div>
-    <span>Price</span>
-    <span class="right"> {{price}}</span>
-  </div>
-  <div>
-    <span>Position Value:</span>
-    <span class="right"> {{portfolioValue}}</span>
-  </div>
-  <i></i>
-</div>
+  </span></div>

--- a/src/app/components/info-panel/info-panel.component.scss
+++ b/src/app/components/info-panel/info-panel.component.scss
@@ -1,6 +1,6 @@
 .gradient-wrapper {
   text-align: left;
-  margin-top: 30px;
+  margin-top: 5px;
   font-weight: 300;
 
   .txt {
@@ -14,16 +14,16 @@
 
 .gradient {
   background: linear-gradient(to bottom, #42931d, #fc5e59);
-  height: 348px;
+  height: 373px;
   border-top: 2px solid #ffffff;
   border-bottom: 2px solid #ffffff;
   border-bottom-right-radius: 8px;
   border-bottom-left-radius: 8px;
   padding-bottom: 2px;
   overflow: hidden;
+  position: relative;
 
-  div {
-    display: flex;
+  .line {
     height: 33%;
     position: relative;
 
@@ -33,25 +33,25 @@
     }
   }
 
-  .dashed {
+  .line.gain50 {
     border-bottom: 2px dashed #ffffff;
   }
 
-  .dotted {
+  .line.current {
     border-bottom: 2px dotted #ffffff;
   }
 
-  .solid {
+  .at-cursor {
     position: absolute;
     border-bottom: 1px solid #ffffff;
-    top: 438px;
     height: 1px;
     width: 100%;
   }
+
 }
 
 .bighint {
-  display: inline-block;
+  left: 100px;
   width: 160px;
   height: 46px;
   background-color: white;
@@ -74,26 +74,26 @@
     font-size: 14px;
     font-weight: 300;
   }
-}
 
-.bighint i {
-  position: absolute;
-  top: 99%;
-  left: 12%;
-  width: 25px;
-  height: 15px;
-  overflow: hidden;
-}
+  i {
+    position: absolute;
+    top: 99%;
+    left: 12%;
+    width: 25px;
+    height: 15px;
+    overflow: hidden;
+  }
 
-.bighint i::after {
-  content: '';
-  position: absolute;
-  width: 15px;
-  height: 15px;
-  left: 50%;
-  transform: translate(-50%, -50%) rotate(45deg);
-  background-color: #ffffff;
-  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.5);
+  i::after {
+    content: '';
+    position: absolute;
+    width: 15px;
+    height: 15px;
+    left: 50%;
+    transform: translate(-50%, -50%) rotate(45deg);
+    background-color: #ffffff;
+    box-shadow: 0 1px 8px rgba(0, 0, 0, 0.5);
+  }
 }
 
 .descriptions {
@@ -252,9 +252,6 @@
     }
 
   }
-  .hide {
-    display: none;
-  }
   .gradient-wrapper {
     font-size: 15px;
   }
@@ -262,25 +259,24 @@
     .solid {
       width: 90%;
     }
-  }
+    .bighint i {
+      top: 50%;
+      left: -12px;
+      margin-top: -12px;
+      width: 12px;
+      height: 24px;
+      overflow: hidden;
+    }
 
-  .bighint i {
-    top: 50%;
-    left: -12px;
-    margin-top: -12px;
-    width: 12px;
-    height: 24px;
-    overflow: hidden;
-  }
+    .bighint i::after {
+      width: 12px;
+      height: 12px;
+      left: 0;
+      top: 50%;
+      transform: translate(50%, -50%) rotate(-45deg);
+      box-shadow: 0 1px 8px rgba(0, 0, 0, 0.5);
+    }
 
-  .bighint i::after {
-    width: 12px;
-    height: 12px;
-    left: 0;
-    top: 50%;
-    transform: translate(50%, -50%) rotate(-45deg);
-    box-shadow: 0 1px 8px rgba(0, 0, 0, 0.5);
   }
 
 }
-

--- a/src/app/components/info-panel/info-panel.component.ts
+++ b/src/app/components/info-panel/info-panel.component.ts
@@ -1,7 +1,7 @@
-import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, Input, OnInit, ViewChild, AfterViewInit } from '@angular/core';
 import { ToolTipComponent } from '../tool-tip-component';
 import { MiddlewareService } from '../../services/middleware/middleware.service';
-import { combineLatest, Observable } from 'rxjs';
+import { combineLatest, Observable, fromEvent, merge } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
 
@@ -15,30 +15,26 @@ export class InfoPanelComponent extends ToolTipComponent implements OnInit {
   @Input() leverage$: Observable<number>;
   @Input() quantity$: Observable<number>;
   @Input() price$: Observable<number>;
+  @ViewChild('gradient') gradient: ElementRef<HTMLDivElement>;
   @ViewChild('priceLine') priceLine: ElementRef<HTMLDivElement>;
   @ViewChild('dashedLine') dashedLine: ElementRef<HTMLDivElement>;
   @ViewChild('dottedLine') dottedLine: ElementRef<HTMLDivElement>;
   @ViewChild('toolTipBox') toolTipBox: ElementRef<HTMLDivElement>;
   @ViewChild('bottomLineText') bottomLineText: ElementRef<HTMLDivElement>;
-  priceLineStyle: Attr;
-  toolTipStyle: Attr;
-  bottomLineTextStyle: Attr;
-  // priceLine: TemplateRef<HTMLDivElement>;
   isHideDetails = true;
   isShowDetails = false;
-  isBannerShown = false;
+  isMouseInChart = false;
 
   liquidationPrice$: Observable<number>;
-  liquidationPenaltyProcentage$: Observable<number>;
+  liquidationLossPercentage$: Observable<number>;
   portfolioValue$: Observable<number>;
   priceToGain100$: Observable<number>;
   priceToGain50$: Observable<number>;
   priceToGain0$: Observable<number>;
   priceToLose50$: Observable<number>;
-  percentToLoose$: Observable<number>;
-
-  portfolioValue: number;
-  price: number;
+  maxLossPercentage$: Observable<number>;
+  priceAtCursor$: Observable<number>;
+  portfolioValueAtCursor$: Observable<number>;
 
   constructor(
     private middleware: MiddlewareService,
@@ -48,26 +44,24 @@ export class InfoPanelComponent extends ToolTipComponent implements OnInit {
 
   ngOnInit() {
     this.liquidationPrice$ = this.middleware.liquidationPrice$(this.leverage$);
-    this.liquidationPenaltyProcentage$ = this.middleware.liquidationPenaltyPercentage$(this.leverage$);
+    this.liquidationLossPercentage$ = this.middleware.liquidationPenaltyPercentage$(this.leverage$)
+      .pipe(
+        startWith(-0.6),
+        map(x => -x)
+      );
     this.portfolioValue$ = this.middleware.positionValueInUsdAtFuturePrice$(this.price$, this.leverage$, this.quantity$);
     this.priceToGain100$ = this.middleware.futurePriceInUsdForPercentChange$(100, this.leverage$);
     this.priceToGain50$ = this.middleware.futurePriceInUsdForPercentChange$(50, this.leverage$);
     this.priceToGain0$ = this.middleware.futurePriceInUsdForPercentChange$(0, this.leverage$);
     this.priceToLose50$ = this.middleware.futurePriceInUsdForPercentChange$(-50, this.leverage$);
-    this.percentToLoose$ = this.middleware.percentageChangeForFuturePrice$(this.liquidationPrice$, this.leverage$)
+    this.maxLossPercentage$ = this.middleware.percentageChangeForFuturePrice$(this.liquidationPrice$, this.leverage$)
       .pipe(
-        startWith(0.5),
+        startWith(-0.5),
         map(x => -x),
       );
-
-    this.price$.subscribe(price => this.price = price);
-    this.portfolioValue$.subscribe(portfolioValue => this.portfolioValue = portfolioValue);
-
-    this.priceLineStyle = this.priceLine.nativeElement.attributes.getNamedItem('style');
-    const dashedLineStyle = this.dashedLine.nativeElement.attributes.getNamedItem('style');
-    const dottedLineStyle = this.dottedLine.nativeElement.attributes.getNamedItem('style');
-    this.toolTipStyle = this.toolTipBox.nativeElement.attributes.getNamedItem('style');
-    this.bottomLineTextStyle = this.bottomLineText.nativeElement.attributes.getNamedItem('style');
+    this.priceAtCursor$ = combineLatest(this.priceToGain100$, this.liquidationPrice$, fromEvent<MouseEvent>(this.gradient.nativeElement, 'pointermove'))
+      .pipe(map(this.mouseMoveInChart));
+    this.portfolioValueAtCursor$ = this.middleware.positionValueInUsdAtFuturePrice$(this.priceAtCursor$, this.leverage$, this.quantity$);
 
     combineLatest(
       this.priceToGain100$,
@@ -77,21 +71,16 @@ export class InfoPanelComponent extends ToolTipComponent implements OnInit {
     ).subscribe(([price100, price50, price0, priceLiquidation]) => {
       const dashedValueNormalized = (price50 - priceLiquidation) / (price100 - priceLiquidation);
       const dottedValueNormalized = (price0 - priceLiquidation) / (price100 - priceLiquidation);
-      // priceLineStyle.value = `top: ${614 + (262 - 614) * normalizedValue}px`;
-      dashedLineStyle.value = `top: ${235 + (-118 - 235) * dashedValueNormalized}px`;
-      dottedLineStyle.value = `top: ${118 + (-235 - 118) * dottedValueNormalized}px`;
-    });
-
-    this.middleware.isAccessDenied$.subscribe(isAccessDenied => {
-      this.isBannerShown = isAccessDenied || !MiddlewareService.isWeb3Compatible();
+      this.dashedLine.nativeElement.setAttribute('style', `top: ${235 + (-118 - 235) * dashedValueNormalized}px`);
+      this.dottedLine.nativeElement.setAttribute('style', `top: ${118 + (-235 - 118) * dottedValueNormalized}px`);
     });
 
     // shift the bottom text to avoid overlapping
     this.leverage$.subscribe(leverage => {
       if (leverage > 2.8) {
-        this.bottomLineTextStyle.value = `padding-left: 80px;`;
+        this.bottomLineText.nativeElement.setAttribute('style', `padding-left: 80px;`);
       } else {
-        this.bottomLineTextStyle.value = ``;
+        this.bottomLineText.nativeElement.removeAttribute('style');
       }
     });
 
@@ -102,22 +91,27 @@ export class InfoPanelComponent extends ToolTipComponent implements OnInit {
     this.isShowDetails = !this.isShowDetails;
   }
 
-  mouseEnterChart(event: MouseEvent) {
-    this.mouseMoveInChart(event);
+  mouseMoveInChart = ([priceToGain100, liquidationPrice, mouseEvent]: [number, number, MouseEvent]) => {
+    const gradientElement = this.gradient.nativeElement;
+    const expandElement = gradientElement.parentElement.parentElement;
+    const gradientClientY = gradientElement.getBoundingClientRect().top;
+    const gradientPageY = gradientClientY + window.scrollY;
+    const expandClientY = expandElement.getBoundingClientRect().top;
+    const expandPageY = expandClientY + window.scrollY;
+    const mouseRelativeToGradientY = mouseEvent.pageY - gradientPageY;
+    const mouseRelativeToExpandY = mouseEvent.pageY - expandPageY;
+    const gradientHeight = gradientElement.getBoundingClientRect().height;
+    this.priceLine.nativeElement.setAttribute('style', `top: ${mouseRelativeToGradientY - 5}px`);
+    this.toolTipBox.nativeElement.setAttribute('style', `top: ${mouseRelativeToExpandY}px`);
+    return Math.round(priceToGain100 - (mouseRelativeToGradientY / gradientHeight) * (priceToGain100 - liquidationPrice));
   }
 
-  mouseMoveInChart(event: MouseEvent) {
-    // this.priceLineStyle.value = `top: ${event.screenY - 30}px`;  // 30 === gradient-wrapper.margin
-
-    // 145 - default offset; 85 - in case of warning;
-    this.priceLineStyle.value = `top: ${event.pageY - 145 - (this.isBannerShown ? 85 : 0)}px`;
-    // 262px - 612px
-    this.toolTipStyle.value = `top: ${event.pageY - 145 - (this.isBannerShown ? 85 : 0) - 81}px; left: ${event.layerX - 35}px`;
+  mouseEnterChart() {
+    this.isMouseInChart = true;
   }
 
   mouseLeaveChart() {
-    this.priceLineStyle.value = 'display: none;';
-    this.toolTipStyle.value = 'display: none;';
+    this.isMouseInChart = false;
   }
 
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -11,7 +11,7 @@ export const environment = {
   liquidLongContractAddress: '0xF3BCABD8FAE29F75BE271EBE2499EDB4C7C139B7',
   defaultEthPriceInUsd: 195,
   timeoutToSwitchToJsonRpc: 10000,    // milliseconds
-  jsonRpcAddress: 'http://127.0.0.1:8545',
+  jsonRpcAddress: 'http://127.0.0.1:1235',
   defaultProviderFeeRate: 0.21,
   web3PollingInterval: 1000,          // milliseconds: how often we should hammer the provider (e.g., MetaMask) for block updates and such
   ethPricePollingFrequency: 3000,     // frequency in milliseconds


### PR DESCRIPTION
* presents the correct data in the tooltip.
* properly positions the tooltip and hover line when there is a banner (and other similar situations).
* positions the tooltip box toward the center of the chart, rather than having its X axis move with the cursor.
* adjusts legend copy and style.
* hides legend when leverage is not yet available

Also renamed a few of the CSS classes to be a bit more clear as to what they were.  e.g., `dashed` to `line gain50`