### PR TITLE
Switches to using the correct mechanism for rounding on cost input.

### DIFF
--- a/src/app/components/confirm-panel/confirm-panel.component.html
+++ b/src/app/components/confirm-panel/confirm-panel.component.html
@@ -22,21 +22,15 @@
     </button>
   </div>
 
-
   <div class="tooltip" outsideClickable (clickOutside)="clickedOutside($event)" *ngIf="isTooltipVisible">
-    <div class="left">
-      <p class="bold">Total Price</p>
-      <p>Leverage Amount</p>
-      <p>Exchange Cost</p>
-      <p>Service Fee</p>
-    </div>
-
-    <div class="right">
-      <p class="bold">{{totalPrice | number:'1.1-9'}} ETH</p>
-      <p>{{leverageAmount | number:'1.1-9'}} ETH</p>
-      <p>{{exchangeCost | number:'1.1-9'}} ETH</p>
-      <p>{{serviceFee | number:'1.1-9'}} ETH</p>
-    </div>
+    <p class="bold" style="grid-column: 1; grid-row: 1">Total Price</p>
+    <p class="bold" style="grid-column: 2; grid-row: 1">{{totalPrice | number:'1.1-9'}} ETH</p>
+    <p style="grid-column: 1; grid-row: 2">Leverage Amount</p>
+    <p style="grid-column: 2; grid-row: 2">{{leverageAmount | number:'1.1-9'}} ETH</p>
+    <p style="grid-column: 1; grid-row: 3">Exchange Cost</p>
+    <p style="grid-column: 2; grid-row: 3">{{exchangeCost | number:'1.1-9'}} ETH</p>
+    <p style="grid-column: 1; grid-row: 4">Service Fee</p>
+    <p style="grid-column: 2; grid-row: 4">{{serviceFee | number:'1.1-9'}} ETH</p>
     <i></i>
   </div>
 </div>

--- a/src/app/components/confirm-panel/confirm-panel.component.scss
+++ b/src/app/components/confirm-panel/confirm-panel.component.scss
@@ -47,6 +47,10 @@
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.19);
     transform: translateY(4px);
   }
+  .tooltip {
+    display: grid;
+    grid-template-columns: 1fr max-content;
+  }
 }
 
 .tooltip {

--- a/src/app/components/input-cost/input-cost.component.spec.ts
+++ b/src/app/components/input-cost/input-cost.component.spec.ts
@@ -97,46 +97,4 @@ describe('InputFeeComponent', () => {
     });
   });
 
-  describe('rounding function to avoid long ugly fractions', () => {
-
-    const dataArr = [
-      { in: 1, out: 1 },
-      { in: 123, out: 123 },
-      { in: 1.1, out: 1.1 },
-      { in: 1.555, out: 1.555 },
-      { in: 1.3339, out: 1.334 },
-      { in: 12.6666, out: 12.667 },
-      { in: 12.6665, out: 12.6661 },
-      { in: 0.050000000000000044, out: 0.0501 },
-      { in: 0.10000000000000009, out: 0.1001 },
-      { in: 0.04500000000000004, out: 0.0451 },
-      { in: 0.09000000000000008, out: 0.0901 },
-      { in: 0.050000000000000044, out: 0.0501 },
-      { in: 0.10000000000000009, out: 0.1001 },
-      { in: 0.05500000000000016, out: 0.0551 },
-      { in: 0.11000000000000032, out: 0.1101 },
-      { in: 0.06000000000000005, out: 0.0601 },
-      { in: 0.1200000000000001, out: 0.1201 },
-      { in: 0.06500000000000017, out: 0.0651 },
-      { in: 0.13000000000000034, out: 0.1301 },
-      { in: 0.07000000000000006, out: 0.0701 },
-      { in: 0.14000000000000012, out: 0.1401 },
-      { in: 0.07500000000000018, out: 0.0751 },
-      { in: 0.15000000000000036, out: 0.1501 },
-      { in: 0.08000000000000007, out: 0.0801 },
-      { in: 0.16000000000000014, out: 0.1601 },
-      { in: 0.08499999999999996, out: 0.085 },
-      { in: 0.16999999999999993, out: 0.17 },
-    ];
-    for (let i = 0; i < dataArr.length; i++) {
-      it(`${i + 1}: should return ${dataArr[i].out} by getting ${dataArr[i].in}`, () => {
-        expect(
-          InputCostComponent.fixRounding(dataArr[i].in),
-          // InputCostComponent.toSignificantFigures(dataArr[i].in, 2, Math.ceil)
-        ).toEqual(dataArr[i].out);
-      });
-    }
-
-  });
-
 });

--- a/src/app/components/input-cost/input-cost.component.ts
+++ b/src/app/components/input-cost/input-cost.component.ts
@@ -16,26 +16,6 @@ export class InputCostComponent extends TooltipComponent implements OnInit {
   maxValue = 250;
   numberValue: number;
 
-  static fixRounding(value: number, numberOfRepetitions = 3): number {
-    const stringValue = value.toString();
-    const pointPosition = stringValue.search(/\./);
-    const repeatingPosition = stringValue.search( new RegExp(`(\\d)\\1{${numberOfRepetitions - 1},}`));
-    if (pointPosition === -1 || repeatingPosition === -1) {   // if integer or there is no cyclic repetitions means no rounding error
-      return value;
-    }
-    const fractionDigits = Math.max( repeatingPosition - pointPosition - 1, numberOfRepetitions);
-
-    // incrementing the value ultimate digit;
-    const newStringValue = value.toFixed(fractionDigits);
-    const newValue = +newStringValue;
-    if (newValue < value) {
-      // incrementing the value ultimate digit
-      const fixedValue = newStringValue.substring(0, newStringValue.length - 1) + (newStringValue.substr(-1) + 1);
-      return +fixedValue;
-    } else {
-      return +value.toFixed(fractionDigits);
-    }
-  }
 
   static toSignificantFigures(value: number, numberOfSignificantFigures: number, roundingFunction: (number) => number): number {
     // early return for 0
@@ -61,12 +41,8 @@ export class InputCostComponent extends TooltipComponent implements OnInit {
 
   ngOnInit() {
     this.exchangeCostRangeLimits$.subscribe(({low, high}) => {
-      // this.minValue = low;
-      // this.maxValue = high;
-      // this.minValue = InputCostComponent.toSignificantFigures(low, 2, Math.ceil);
-      // this.maxValue = InputCostComponent.toSignificantFigures(high, 2, Math.ceil);
-      this.minValue = InputCostComponent.fixRounding(low);
-      this.maxValue = InputCostComponent.fixRounding(high);
+      this.minValue = InputCostComponent.toSignificantFigures(low, 2, Math.ceil);
+      this.maxValue = InputCostComponent.toSignificantFigures(high, 2, Math.ceil);
       this.value$.emit((this.minValue + this.maxValue) / 2);
     });
   }


### PR DESCRIPTION
The code had 3 mechanisms for setting the `minValue` and `maxValue` for the input cost, with 2 commented out.  This change removes the incorrect two and uncomments the correct one.

Note: The code for one of the solutions was deleted, but it will be retained in git history if we need it back for something later.