### PR TITLE
Fixes bug where ethereum-not-enabled banner would sometimes not appear.

### DIFF
--- a/src/app/pages/main-page/main-page.component.html
+++ b/src/app/pages/main-page/main-page.component.html
@@ -8,10 +8,10 @@
   </div>
 </div>
 
-<div class="warning" *ngIf="this.middleware.isAccessDenied$ | async">
+<div class="warning" *ngIf="!(this.middleware.ethereumEnabled$ | async)">
   <div class="inner">
     <div class="bold icon"><img src="assets/warning.png"/>Warning</div>
-    <div class="text">To utilize all of the features of this tool, you must allow Ethereum account access. <a href class="red nobreak">Re-prompt for account access.</a>
+    <div class="text">To utilize all of the features of this tool, you must allow Ethereum account access. <span class="pointer red nobreak" (click)="enableEthereumReprompt()">Re-prompt for account access.</span>
     </div>
   </div>
 </div>

--- a/src/app/pages/main-page/main-page.component.scss
+++ b/src/app/pages/main-page/main-page.component.scss
@@ -28,6 +28,10 @@
   }
 }
 
+.pointer {
+  cursor: pointer;
+}
+
 .container {
   display: grid;
   grid-template-columns: 50% auto;

--- a/src/app/pages/main-page/main-page.component.ts
+++ b/src/app/pages/main-page/main-page.component.ts
@@ -101,6 +101,10 @@ export class MainPageComponent implements OnInit {
     }
   }
 
+  enableEthereumReprompt() {
+    this.middleware.enableEthereum().catch(() => {})
+  }
+
   onSubmit() {
     this.logger.log(`Transaction submitted with values (${this.leverage}, ${this.quantity}, ${this.exchangeCost}, ${this.serviceFee}).`);
 

--- a/src/app/services/middleware/middleware.service.ts
+++ b/src/app/services/middleware/middleware.service.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, Injectable } from '@angular/core';
-import { combineLatest, concat, Observable } from 'rxjs';
-import { ignoreElements, map, mergeMap } from 'rxjs/operators';
+import { combineLatest, concat, Observable, Subject, BehaviorSubject } from 'rxjs';
+import { ignoreElements, map, mergeMap, startWith } from 'rxjs/operators';
 import { fromPromise } from 'rxjs/internal-compatibility';
 import { environment } from '../../../environments/environment';
 
@@ -21,140 +21,101 @@ declare global {
     };
   }
 }
-declare const web3: typeof window.web3;
-declare const ethereum: typeof window.ethereum;
 
 
 @Injectable({
   providedIn: 'root',
 })
 export class MiddlewareService {
-  private provider: AsyncSendable;
   private liquidLong: LiquidLong;
-  private waitingForUserToEnable: Promise<void>;
+  private ethereumEnabled$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   price$ = new EventEmitter<number>();
-  isAccessDenied$ = new EventEmitter<boolean>();
 
   constructor(private logger: LoggerService) {
-    let isMetamaskProvider: boolean;
-
-    if (window.ethereum) {
-      // Modern dapp browsers...
-      this.provider = ethereum;
-
-      // Request account access if needed
-      this.waitingForUserToEnable = new Promise<void>(resolve => {
-        return Promise.race([
-          ethereum.enable(),
-          new Promise((resolve1, reject) => setTimeout(reject, environment.timeoutToSwitchToJsonRpc)),
-        ])
-          .then(() => {
-            // Acccounts now exposed
-            isMetamaskProvider = true;
-            this.isAccessDenied$.emit(false);
-            resolve();
-          })
-          .catch(() => {
-            // User denied account access...
-            this.logger.warn(`User denied account access or timeout`);
-            isMetamaskProvider = false;
-            this.isAccessDenied$.emit(true);
-            resolve();
-          });
-      });
-    } else if (window.web3) {
-      // Legacy dapp browsers...
-      this.provider = web3.currentProvider;
-      // Acccounts always exposed
-      this.waitingForUserToEnable = Promise.resolve();
-      isMetamaskProvider = true;
-    } else {
-      // Non-dapp browsers...
-      this.waitingForUserToEnable = Promise.resolve();
-      isMetamaskProvider = false;
-      this.logger.error('Non-Ethereum browser detected. You should consider trying MetaMask!');
-    }
-
-    this.waitingForUserToEnable
-      .then(() => {
-
-        if (isMetamaskProvider) {
-          this.liquidLong = LiquidLong.createWeb3(
-            this.provider,
-            environment.liquidLongContractAddress,
-            environment.defaultEthPriceInUsd,
-            environment.defaultProviderFeeRate,
-            environment.web3PollingInterval,
-            environment.ethPricePollingFrequency,
-            environment.providerFeePollingFrequency,
-          );
-        } else {
-          this.liquidLong = LiquidLong.createJsonRpc(
-            environment.jsonRpcAddress,
-            environment.liquidLongContractAddress,
-            environment.defaultEthPriceInUsd,
-            environment.defaultProviderFeeRate,
-            environment.web3PollingInterval,
-            environment.ethPricePollingFrequency,
-            environment.providerFeePollingFrequency,
-          );
-        }
-
-        let oldPrice = 0;
-        this.liquidLong.registerForEthPriceUpdated(newEthPriceInUsd => {
-          if (oldPrice !== newEthPriceInUsd) {
-            this.logger.log(`newEthPriceInUsd=`, newEthPriceInUsd);
-            oldPrice = newEthPriceInUsd;
-          }
-          this.price$.emit(newEthPriceInUsd);
-        });
-
-      });
-
+    this.liquidLong = this.createLiquidLong();
+    this.enableEthereum().catch(() => {});
+    let oldPrice = 0;
+    this.liquidLong.registerForEthPriceUpdated(newEthPriceInUsd => {
+      if (oldPrice !== newEthPriceInUsd) {
+        this.logger.log(`newEthPriceInUsd=`, newEthPriceInUsd);
+        oldPrice = newEthPriceInUsd;
+      }
+      this.price$.emit(newEthPriceInUsd);
+    });
   }
 
   static isWeb3Compatible(): boolean {
     return !!(window.ethereum || window.web3);
   }
 
+  public enableEthereum = async (): Promise<void> => {
+    if (window.ethereum) {
+      try {
+        await window.ethereum.enable();
+      } finally {
+        this.ethereumEnabled$.next(false);
+      }
+    }
+    this.ethereumEnabled$.next(true);
+  }
+
+  private createLiquidLong = (): LiquidLong => {
+    if (window.ethereum) {
+      return LiquidLong.createWeb3(
+        window.ethereum,
+        environment.liquidLongContractAddress,
+        environment.defaultEthPriceInUsd,
+        environment.defaultProviderFeeRate,
+        environment.web3PollingInterval,
+        environment.ethPricePollingFrequency,
+        environment.providerFeePollingFrequency,
+      );
+    } else if (window.web3 && window.web3.currentProvider) {
+      return LiquidLong.createWeb3(
+        window.web3.currentProvider,
+        environment.liquidLongContractAddress,
+        environment.defaultEthPriceInUsd,
+        environment.defaultProviderFeeRate,
+        environment.web3PollingInterval,
+        environment.ethPricePollingFrequency,
+        environment.providerFeePollingFrequency,
+      );
+    } else {
+      return LiquidLong.createJsonRpc(
+        environment.jsonRpcAddress,
+        environment.liquidLongContractAddress,
+        environment.defaultEthPriceInUsd,
+        environment.defaultProviderFeeRate,
+        environment.web3PollingInterval,
+        environment.ethPricePollingFrequency,
+        environment.providerFeePollingFrequency,
+      );
+    }
+  }
+
   providerFee$(leverageMultiplier$: Observable<number>, leverageSizeInEth$: Observable<number>): Observable<number> {
     this.logger.log(`method providerFee$`);
-    return concat(
-      fromPromise(this.waitingForUserToEnable).pipe(
-        ignoreElements(),
-      ),
-      combineLatest(leverageMultiplier$, leverageSizeInEth$)
-        .pipe(
-          mergeMap(([leverageMultiplier, leverageSizeInEth]) =>
-            fromPromise(this.liquidLong.getFeeInEth(leverageMultiplier, leverageSizeInEth))),
-        )
-    );
+    return combineLatest(leverageMultiplier$, leverageSizeInEth$)
+      .pipe(
+        mergeMap(([leverageMultiplier, leverageSizeInEth]) =>
+          fromPromise(this.liquidLong.getFeeInEth(leverageMultiplier, leverageSizeInEth))),
+      );
   }
 
   liquidationPrice$(leverageMultiplier$: Observable<number>) {
     this.logger.log(`method liquidationPrice$`);
-    return concat(
-      fromPromise(this.waitingForUserToEnable).pipe(
-        ignoreElements(),
-      ),
-      leverageMultiplier$
-        .pipe(
-          mergeMap(leverage => fromPromise(this.liquidLong.getLiquidationPriceInUsd(leverage))),
-        )
-    );
+    return leverageMultiplier$
+      .pipe(
+        mergeMap(leverage => fromPromise(this.liquidLong.getLiquidationPriceInUsd(leverage))),
+      );
   }
 
   liquidationPenaltyPercentage$(leverageMultiplier$: Observable<number>) {
     this.logger.log(`method liquidationPenaltyPercentage$`);
-    return concat(
-      fromPromise(this.waitingForUserToEnable).pipe(
-        ignoreElements(),
-      ),
-      leverageMultiplier$
-        .pipe(
-          map(leverage => this.liquidLong.getLiquidationPenaltyPercent(leverage)),
-        )
-    );
+    return leverageMultiplier$
+      .pipe(
+        map(leverage => this.liquidLong.getLiquidationPenaltyPercent(leverage)),
+      );
   }
 
   positionValueInUsdAtFuturePrice$(
@@ -163,17 +124,12 @@ export class MiddlewareService {
     leverageSizeInEth$: Observable<number>
   ) {
     this.logger.log(`method positionValueInUsdAtFuturePrice$`);
-    return concat(
-      fromPromise(this.waitingForUserToEnable).pipe(
-        ignoreElements(),
-      ),
-      combineLatest(futurePriceInUsd$, leverageMultiplier$, leverageSizeInEth$)
-        .pipe(
-          mergeMap(([futurePriceInUsd, leverageMultiplier, leverageSizeInEth]) =>
-            fromPromise(this.liquidLong.getPositionValueInUsdAtFuturePrice(futurePriceInUsd, leverageMultiplier, leverageSizeInEth)),
-          ),
-        )
-    );
+    return combineLatest(futurePriceInUsd$, leverageMultiplier$, leverageSizeInEth$)
+      .pipe(
+        mergeMap(([futurePriceInUsd, leverageMultiplier, leverageSizeInEth]) =>
+          fromPromise(this.liquidLong.getPositionValueInUsdAtFuturePrice(futurePriceInUsd, leverageMultiplier, leverageSizeInEth)),
+        ),
+      );
   }
 
   futurePriceInUsdForPercentChange$(
@@ -181,17 +137,12 @@ export class MiddlewareService {
     leverageMultiplier$: Observable<number>,
   ) {
     this.logger.log(`method futurePriceInUsdForPercentChange$`);
-    return concat(
-      fromPromise(this.waitingForUserToEnable).pipe(
-        ignoreElements(),
-      ),
-      leverageMultiplier$
-        .pipe(
-          mergeMap(leverageMultiplier =>
-            fromPromise(this.liquidLong.getFuturePriceInUsdForPercentChange(percentChangeFromCurrent / 100, leverageMultiplier)),
-          ),
-        )
-    );
+    return leverageMultiplier$
+      .pipe(
+        mergeMap(leverageMultiplier =>
+          fromPromise(this.liquidLong.getFuturePriceInUsdForPercentChange(percentChangeFromCurrent / 100, leverageMultiplier)),
+        ),
+      );
   }
 
   percentageChangeForFuturePrice$(
@@ -199,17 +150,12 @@ export class MiddlewareService {
     leverageMultiplier$: Observable<number>,
   ) {
     this.logger.log(`method percentageChangeForFuturePrice$`);
-    return concat(
-      fromPromise(this.waitingForUserToEnable).pipe(
-        ignoreElements(),
-      ),
-      combineLatest(futurePriceInUsd$, leverageMultiplier$)
-        .pipe(
-          mergeMap(([futurePriceInUsd, leverageMultiplier]) =>
-            fromPromise(this.liquidLong.getPercentageChangeForFuturePrice(futurePriceInUsd, leverageMultiplier)),
-          ),
-        ))
-      ;
+    return combineLatest(futurePriceInUsd$, leverageMultiplier$)
+      .pipe(
+        mergeMap(([futurePriceInUsd, leverageMultiplier]) =>
+          fromPromise(this.liquidLong.getPercentageChangeForFuturePrice(futurePriceInUsd, leverageMultiplier)),
+        ),
+      );
   }
 
   estimatedCostsInEth$(
@@ -217,17 +163,12 @@ export class MiddlewareService {
     leverageSizeInEth$: Observable<number>,
   ) {
     this.logger.log(`method estimatedCostsInEth$`);
-    return concat(
-      fromPromise(this.waitingForUserToEnable).pipe(
-        ignoreElements(),
-      ),
-      combineLatest(leverageMultiplier$, leverageSizeInEth$)
-        .pipe(
-          mergeMap(([leverageMultiplier, leverageSizeInEth]) =>
-            fromPromise(this.liquidLong.getEstimatedCostsInEth(leverageMultiplier, leverageSizeInEth)),
-          ),
-        )
-    );
+    return combineLatest(leverageMultiplier$, leverageSizeInEth$)
+      .pipe(
+        mergeMap(([leverageMultiplier, leverageSizeInEth]) =>
+          fromPromise(this.liquidLong.getEstimatedCostsInEth(leverageMultiplier, leverageSizeInEth)),
+        ),
+      );
   }
 
   submit(
@@ -237,18 +178,16 @@ export class MiddlewareService {
     feeLimitInEth: number,
   ) {
     this.logger.log(`method submit`);
-    return this.waitingForUserToEnable
-      .then(() => window.ethereum
-        ? ethereum.enable().catch(() => ethereum.enable())
-        : Promise.resolve()
-      )
-      .then(() => this.liquidLong.openPosition(
-        leverageMultiplier,
-        leverageSizeInEth,
-        costLimitInEth,
-        feeLimitInEth,
-      ));
 
+    return this.enableEthereum()
+      .then(() => {
+        return this.liquidLong.openPosition(
+          leverageMultiplier,
+          leverageSizeInEth,
+          costLimitInEth,
+          feeLimitInEth)
+        }
+      );
   }
 
 }


### PR DESCRIPTION
It is possible that I could have fixed the specific bug with a lighter touch, but I was worried that there would be other subtle issues that popped up without addressing the root cause.

While addressing this bug, I also noticed that there were some features that were dependent on Ethereum account being enabled, when they should not have depended on that.  Now all features should be fully accessible even if you deny Ethereum account access.

Finally, after addressing this bug I realized that the "reprompt for Ethereum access" link was really just refreshing the page.  I changed it to instead just reprompt for access.