### PR TITLE
Rate limits exchange cost fetches and shows spinner while waiting.

### DIFF
--- a/src/app/components/input-cost/input-cost.component.html
+++ b/src/app/components/input-cost/input-cost.component.html
@@ -1,38 +1,46 @@
-<h4 class="input-label">How much are you willing to pay in costs?</h4>
+<div [hidden]="state !== 'input'">
+  <h4 class="input-label">How much are you willing to pay in costs?</h4>
 
-<div class="range-wrapper">
-  <div class="slider-wrapper">
-    <span class="range-background"></span>
-    <input
-        type="range"
-        [ngModel]="numberValue"
-        (ngModelChange)="setValue($event)"
-        [min]="minValue"
-        [max]="maxValue"
-        [step]="(maxValue - minValue)/100"
-        [value]="minValue"
-    >
+  <div class="range-wrapper">
+    <div class="slider-wrapper">
+      <span class="range-background"></span>
+      <input
+          type="range"
+          [ngModel]="numberValue"
+          (ngModelChange)="setValue($event)"
+          [min]="minValue"
+          [max]="maxValue"
+          [step]="(maxValue - minValue)/100"
+          [value]="minValue"
+      >
+    </div>
+    <p class="legend">
+      <span class="left">{{minValue | number:'1.1-9'}}</span> recommended values <span class="right">{{maxValue | number:'1.1-9'}}</span>
+    </p>
   </div>
-  <p class="legend">
-    <span class="left">{{minValue | number:'1.1-9'}}</span> recommended values <span class="right">{{maxValue | number:'1.1-9'}}</span>
-  </p>
+
+  <div class="inputbox">
+    <input type="number"
+          [ngModel]="numberValue"
+          (ngModelChange)="setValue($event)"
+          [min]="minValue"
+          [max]="maxValue"
+          [step]="(maxValue - minValue)/100"
+          [value]="minValue"
+          class="input" placeholder="Between {{minValue | number:'1.1-9'}} and {{maxValue | number:'1.1-9'}}"
+    />
+    <span class="input-suffix yellow bigger bold">ETH</span>
+    <span class="input-suffix material-icons cursorPointer tooltip-button" (click)="toggleTooltip($event)">help</span>
+  </div>
+
+  <div class="tooltip shadow" outsideClickable (clickOutside)="clickedOutside($event)" *ngIf="isTooltipVisible">
+    The maximum amount you are willing to pay in <a target="_blank" rel="noopener nofollow" href="http://help.keydonix.com/articles/33913-what-are-exchange-costs">exchange costs</a>.  Any unused exchange costs will be refunded to you at the end of the transaction.
+    <i></i>
+  </div>
 </div>
 
-<div class="inputbox">
-  <input type="number"
-         [ngModel]="numberValue"
-         (ngModelChange)="setValue($event)"
-         [min]="minValue"
-         [max]="maxValue"
-         [step]="(maxValue - minValue)/100"
-         [value]="minValue"
-         class="input" placeholder="Between {{minValue | number:'1.1-9'}} and {{maxValue | number:'1.1-9'}}"
-  />
-  <span class="input-suffix yellow bigger bold">ETH</span>
-  <span class="input-suffix material-icons cursorPointer tooltip-button" (click)="toggleTooltip($event)">help</span>
+<div class="spinner" [hidden]="state !== 'spinner'">
 </div>
 
-<div class="tooltip shadow" outsideClickable (clickOutside)="clickedOutside($event)" *ngIf="isTooltipVisible">
-  The maximum amount you are willing to pay in <a target="_blank" rel="noopener nofollow" href="http://help.keydonix.com/articles/33913-what-are-exchange-costs">exchange costs</a>.  Any unused exchange costs will be refunded to you at the end of the transaction.
-  <i></i>
+<div class="blank" [hidden]="state !== 'blank'">
 </div>

--- a/src/app/components/input-cost/input-cost.component.scss
+++ b/src/app/components/input-cost/input-cost.component.scss
@@ -79,9 +79,27 @@
   }
 }
 
+.spinner {
+  height: 132px;
+  width: 100%;
+  background: url("../../../assets/preloader.gif") no-repeat center;
+  transform: translateY(4px);
+}
+
+.blank {
+  height: 132px;
+  width: 100%;
+}
+
 .tooltip {
   bottom: 45px;
   i {
     left: calc(100% - 17px);
+  }
+}
+
+@media only screen and (max-width: 830px) {
+  .spinner, .blank {
+    height: 128px;
   }
 }

--- a/src/app/pages/main-page/main-page.component.html
+++ b/src/app/pages/main-page/main-page.component.html
@@ -27,7 +27,7 @@
       <div class="left-main inner-grid">
         <app-input-quantity class="input-quantity" [maxValue]="maxQuantity" (value$)="quantityEmitter$.emit($event)"></app-input-quantity>
         <app-input-leverage class="input-leverage" (value$)="leverageEmitter$.emit($event)"></app-input-leverage>
-        <app-input-fee class="input-cost" [exchangeCostRangeLimits$]="exchangeCostRangeLimits$" (value$)="exchangeCostEmitter$.emit($event)" [style.visibility]="(exchangeCostRangeLimits$ | async) ? 'visible' : 'hidden'"></app-input-fee>
+        <app-input-fee class="input-cost" [exchangeCostRangeLimits$]="exchangeCostRangeLimits$" [leverage$]="leverage$" [quantity$]="quantity$" (value$)="exchangeCostEmitter$.emit($event)"></app-input-fee>
       </div>
 
       <div class="right-main">

--- a/src/app/services/middleware/middleware.service.ts
+++ b/src/app/services/middleware/middleware.service.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, Injectable } from '@angular/core';
 import { combineLatest, Observable, BehaviorSubject } from 'rxjs';
-import { map, mergeMap, filter } from 'rxjs/operators';
+import { map, mergeMap, filter, debounceTime } from 'rxjs/operators';
 import { fromPromise } from 'rxjs/internal-compatibility';
 import { environment } from '../../../environments/environment';
 
@@ -165,6 +165,7 @@ export class MiddlewareService {
     this.logger.log(`method estimatedCostsInEth$`);
     return combineLatest(leverageMultiplier$, leverageSizeInEth$)
       .pipe(
+        debounceTime(500),
         filter(([leverageMultiplier, leverageSizeInEth]) => {
           return !!leverageMultiplier && !!leverageSizeInEth
         }),

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -230,6 +230,7 @@ hr {
 
 .cursorPointer {
   cursor: pointer;
+  user-select: none;
 }
 
 .hidden {


### PR DESCRIPTION
A user could cause great harm to the backend server by just dragging the leverage slider back and forth which results rapid (every tick of the event loop) requests to the remote node in the form of an `eth_call`.  This is now rate limited such that the user needs to not change the leverage multiplier or amount for 500ms before the request is made, at which point it will make the request on behalf.

In order to maintain a quality user experience, a spinner has been added to let the user know that they are waiting on data from the server.  This also prevents them from clicking through to the end without reviewing the exchange costs.

Also fixes a minor bug where the leverage amount buttons were selectable.

Fixes #19 