### PR TITLE
Updates contract address and fixes bug for real this time.

### DIFF
--- a/src/app/pages/main-page/main-page.component.ts
+++ b/src/app/pages/main-page/main-page.component.ts
@@ -15,7 +15,6 @@ export class MainPageComponent implements OnInit {
 
   maxQuantity$ = this.middleware.maxLeverageSize$.pipe(
     map(x => MainPageComponent.toSignificantFigures(x, 2, Math.floor)),
-    shareReplay(1),
   );
   price$ = this.middleware.price$.pipe(
     catchError((err, caught) => {
@@ -23,7 +22,6 @@ export class MainPageComponent implements OnInit {
       this.isNotConnected = true;
       return caught;
     }),
-    shareReplay(1),
   );
 
   isDebug = false;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,7 +3,7 @@
 export const environment = {
   production: true,
   minQuantity: 0.001, // min value and step size
-  liquidLongContractAddress: '0x3Bd3d07a2d352E7CA098CCcb2b0882c9f45597D2',
+  liquidLongContractAddress: '0xe61669566c4bf676ae6b55252c457a192bd26a9e',
   defaultEthPriceInUsd: 150,
   jsonRpcAddress: 'https://eth-mainnet.alchemyapi.io/jsonrpc/7sE1TzCIRIQA3NJPD5wg7YRiVjhxuWAE',
   defaultProviderFeeRate: 0.01,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
   production: false,
   minQuantity: 0.001, // min value and step size
-  // liquidLongContractAddress: '0x3Bd3d07a2d352E7CA098CCcb2b0882c9f45597D2',
+  // liquidLongContractAddress: '0xe61669566c4bf676ae6b55252c457a192bd26a9e',
   liquidLongContractAddress: '0xB03CF72BC5A9A344AAC43534D664917927367487',
   defaultEthPriceInUsd: 150,
   // jsonRpcAddress: 'https://eth-mainnet.alchemyapi.io/jsonrpc/7sE1TzCIRIQA3NJPD5wg7YRiVjhxuWAE',


### PR DESCRIPTION
I thought I had fixed the bug where going back after landing on the error/success page would result in needing to wait for a full polling cycle before values showed up, but I was wrong (I even tested it... I thought!).  The `main-page` is torn down and reconstructed when you navigate to success/fail pages, so the shareReplay needed to be moved up the stack so it would be retained when the page is rebuilt.