### PR TITLE
Remove mention of Brave browser.

### DIFF
--- a/src/app/pages/main-page/main-page.component.html
+++ b/src/app/pages/main-page/main-page.component.html
@@ -2,9 +2,7 @@
   <div>
     <div class="banner" *ngIf="isWrongBrowser">
       <div class="bold icon"><img src="assets/warning.png" alt="warning sign"/>Warning</div>
-      <div class="text">To utilize all of the features, you must use an Ethereum enabled browser such as <a href="https://brave.com" target="_blank"
-        class="red">Brave</a> or a browser extension like <a href="https://metamask.io" target="_blank"
-        class="red">MetaMask</a>.
+      <div class="text">To utilize all of the features, you must use an Ethereum enabled browser such as a browser with an extension like <a href="https://metamask.io" target="_blank" class="red">MetaMask</a>.
       </div>
     </div>
 


### PR DESCRIPTION
Apparently Brave doesn't come packaged with MetaMask anymore, you have to add it as an extension just like Chrome or Firefox, and you can't use the built-in Ethereum wallet.  Sad days.